### PR TITLE
Fixed parameters list naming error in create_processes

### DIFF
--- a/R/processes.R
+++ b/R/processes.R
@@ -281,7 +281,7 @@ create_SE_process <- function(variables_list, events_list, parameters_list, rend
     total_FOI <- household_FOI + workplace_FOI + school_FOI + leisure_FOI + community_FOI
 
     # Render the setting-specific FOIs is diagnostic rendering turned on:
-    if(parameters$render_diagnostics) {
+    if(parameters_list$render_diagnostics) {
       renderer$render('FOI_household', max(household_FOI), t)
       renderer$render('FOI_workplace', max(workplace_FOI), t)
       renderer$render('FOI_school', max(school_FOI), t)


### PR DESCRIPTION
In the part of `create_processes()` that decides whether to render the FOI (when `render_diagnostics == TRUE)`, `parameters` rather than `parameters_list` was called, so I've changed it to `parameters_list`.