### PR TITLE
Fixed setting sizes calling in generate_far_uvc_switches()

### DIFF
--- a/R/interventions.R
+++ b/R/interventions.R
@@ -121,7 +121,7 @@ generate_far_uvc_switches <- function(parameters_list, variables_list) {
     if(parameters_list$far_uvc_workplace_coverage_type == "targeted") {
 
       # Get the indices of the indices of workplaces with Far UVC based on their sizes:
-      indices_of_workplaces_with_uvc <- sort(x = variables_list$setting_sizes$workplace,
+      indices_of_workplaces_with_uvc <- sort(x = parameters_list$setting_sizes$workplace,
                                              decreasing = TRUE,
                                              index.return = TRUE)$ix[1:number_of_workplaces_with_uvc]
 
@@ -165,7 +165,7 @@ generate_far_uvc_switches <- function(parameters_list, variables_list) {
     if(parameters_list$far_uvc_school_coverage_type == "targeted") {
 
       # Get the indices of the indices of schools with Far UVC based on their sizes:
-      indices_of_schools_with_uvc <- sort(x = variables_list$setting_sizes$school,
+      indices_of_schools_with_uvc <- sort(x = parameters_list$setting_sizes$school,
                                           decreasing = TRUE,
                                           index.return = TRUE)$ix[1:number_of_schools_with_uvc]
 
@@ -209,7 +209,7 @@ generate_far_uvc_switches <- function(parameters_list, variables_list) {
     if(parameters_list$far_uvc_leisure_coverage_type == "targeted") {
 
       # Get the indices of the indices of leisure settings with Far UVC based on their sizes:
-      indices_of_leisures_with_uvc <- sort(x = variables_list$setting_sizes$leisure,
+      indices_of_leisures_with_uvc <- sort(x = parameters_list$setting_sizes$leisure,
                                            decreasing = TRUE,
                                            index.return = TRUE)$ix[1:number_of_leisures_with_uvc]
 
@@ -254,7 +254,7 @@ generate_far_uvc_switches <- function(parameters_list, variables_list) {
     if(parameters_list$far_uvc_household_coverage_type == "targeted") {
 
       # Get the indices of the indices of households with Far UVC based on their sizes:
-      indices_of_households_with_uvc <- sort(x = variables_list$setting_sizes$household,
+      indices_of_households_with_uvc <- sort(x = parameters_list$setting_sizes$household,
                                              decreasing = TRUE,
                                              index.return = TRUE)$ix[1:number_of_households_with_uvc]
 

--- a/R/variables.R
+++ b/R/variables.R
@@ -86,18 +86,18 @@ create_variables <- function(parameters_list) {
     specific_leisure = specific_day_leisure_variable
   )
 
+  # Store setting sizes in a list:
+  setting_sizes <- get_setting_sizes(variables_list = variables_list,
+                                     leisure_sizes = leisure_setting_sizes)
+
+  # Append setting sizes to variables_list:
+  parameters_list$setting_sizes <- setting_sizes
+
   # If any setting has UVC installed, retrieve the sizes of all of the settings:
   if(any(parameters_list$far_uvc_workplace,
          parameters_list$far_uvc_school,
          parameters_list$far_uvc_leisure,
          parameters_list$far_uvc_household)) {
-
-    # Store setting sizes in a list:
-    setting_sizes <- get_setting_sizes(variables_list = variables_list,
-                                       leisure_sizes = leisure_setting_sizes)
-
-    # Append setting sizes to variables_list:
-    parameters_list$setting_sizes <- setting_sizes
 
     # Generate and append the far UVC switches for settings in which it has been switched on:
     parameters_list <- generate_far_uvc_switches(parameters_list, variables_list)


### PR DESCRIPTION
Simulations were erroring out when `set_uvc()` was used to specify far UVC deployment with the targeted setting. This was because the setting sizes required to get the indices of settings to target were stored in the `parameters_list`, but were attempting to be called from the `variables_list`. I've fixed this in `generate_far_uvc_switches()`, and also moved the step getting the setting sizes outside of the `if()` statement for `far_uvc` in `create_variables()`.