### PR TITLE
Added checks for setting-specific beta lengths to address issue #69

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -156,12 +156,12 @@ get_parameters <- function(overrides = list()) {
   }
 
   # Check that all setting-specific betas are of length 1:
-  if(any(length(parameters$beta_household) > 1,
-         length(parameters$beta_school) > 1,
-         length(parameters$beta_workplace) > 1,
-         length(parameters$beta_leisure) > 1,
-         length(parameters$beta_community) > 1)) {
-    stop("ERROR: A setting-specific beta has length greater than 1. All setting-specific betas must be of length 1")
+  if(any(length(parameters$beta_household) != 1,
+         length(parameters$beta_school) != 1,
+         length(parameters$beta_workplace) != 1,
+         length(parameters$beta_leisure) != 1,
+         length(parameters$beta_community) != 1)) {
+    stop("ERROR: A setting-specific beta has length not equal to 1. All setting-specific betas must be of length 1")
   }
 
 

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -5,6 +5,6 @@ test_that("get_parameters() errors when a setting-specific beta has length great
                                                                       beta_workplace = c(0.01),
                                                                       beta_leisure = c(0.455, 0.3),
                                                                       beta_community = c(0.4))),
-               regexp = "ERROR: A setting-specific beta has length greater than 1. All setting-specific betas must be of length 1")
+               regexp = "ERROR: A setting-specific beta has length not equal to 1. All setting-specific betas must be of length 1")
 
 })


### PR DESCRIPTION
Added a check to `get_parameters()` to ensure all `beta_SETTING` parameters are of length 1. 

Added a unit test to test-parameters.R to check that the checks work as expected.

Checked that all other unit tests are not affected by the change.