### PR TITLE
Incidence Rendering

### DIFF
--- a/R/processes.R
+++ b/R/processes.R
@@ -309,7 +309,7 @@ create_SE_process <- function(variables_list, events_list, parameters_list, rend
     S$sample(rate = p_inf_currently_S)
 
     # Render the number of people going from susceptible to infected:
-    renderer$render('n_new_exposed', S$size(), t)
+    renderer$render('E_new', S$size(), t)
 
     # Queue an update to the infectious state of the newly infected susceptible individuals to Exposed:
     variables_list$disease_state$queue_update(value = "E",index = S)

--- a/tests/testthat/test-rendering.R
+++ b/tests/testthat/test-rendering.R
@@ -11,7 +11,7 @@ test_that("run_simulations() correctly fails to render diagnostic outputs when r
 
   # Set up a vector of expected column names:
   expected_columns_names <- c("timestep",
-                              "n_new_exposed",
+                              "E_new",
                               "S_count",
                               "E_count",
                               "I_count",
@@ -45,7 +45,7 @@ test_that("run_simulations() correctly renders diagnostic outputs when render_di
                               "FOI_leisure",
                               "FOI_community",
                               "FOI_total",
-                              "n_new_exposed",
+                              "E_new",
                               "S_count",
                               "E_count",
                               "I_count",


### PR DESCRIPTION
Have added a line to `create_SE_process()` that renders `S$size()`, the number of individuals that will be scheduled for a state transition from S -> E (in other words the number of new infections.

I have called this `n_new_exposed` but open to improvements (`n_infections`, `incidence`, etc.).

Note that, when looking at the dataframe output by `run_simulations()`, this new column is "out of step" with the SEIR numbers. I think this is due to the fact that we render the number of new infections in the current time step, but the states of the newly exposed individuals (or infected/recovered/susceptible for that matter) do not update until the end of the timestep and are then captured in the SEIR numbers for the following timestep.