### PR TITLE
Added Pathogen Archetypes

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -60,9 +60,10 @@
 #' * `far_uvc_household_coverage`: Proportion of households covered with far UVC (must be a numeric value between 0 and 1)
 #' * `far_uvc_household_efficacy`: : Efficacy of far UVC in the household setting (must be a numeric value between 0 and 1)
 #' * `far_uvc_household_timestep`: The timestep on which far UVC is implemented in the household setting (must be a numeric value greater than or equal to 0)
+#' @param archetype A text string indicating the pathogen archetype parameter set to load (default = "none", current options are flu, sars_cov_2, and measles)
 #' @family parameters
 #' @export
-get_parameters <- function(overrides = list()) {
+get_parameters <- function(overrides = list(), archetype = "none") {
 
   # Open a list of parameters to store
   parameters <- list(
@@ -85,6 +86,7 @@ get_parameters <- function(overrides = list()) {
     leisure_mean_size = 50,
     leisure_overdispersion_size = 2,
     leisure_prop_max = 0.1,
+
     duration_exposed = 2,
     duration_infectious = 4,
     beta_household = 0.5, # check this as default
@@ -141,6 +143,11 @@ get_parameters <- function(overrides = list()) {
     parameters[[name]] <- overrides[[name]]
   }
 
+  # Ensure archetype input from recognised options:
+  if(!(archetype %in% c("none", "flu", "measles", "sars_cov_2"))) {
+    stop('archetype not recognised')
+  }
+
   # Check if dt is < 1 and whether it can evenly divide 1 (i.e. 1/x should return an integer)
   if (parameters$dt > 1 | parameters$dt == 0) {
     stop("dt must be less than 1 and greater than 0")
@@ -158,6 +165,40 @@ get_parameters <- function(overrides = list()) {
   }
   if (parameters$endemic_or_epidemic == "endemic" & is.null(parameters$prob_inf_external)) {
     stop("prob_inf_external must be specified if endemic_or_epidemic is set to endemic")
+  }
+
+  # Overwrite parameters if archetype specified:
+  # Flu (R0 ~ 1.5)
+  if(archetype == "flu") {
+    parameters$duration_exposed = 1
+    parameters$duration_infectious = 2
+    parameters$beta_household = 0.132
+    parameters$beta_workplace = 0.132
+    parameters$beta_school = 0.132
+    parameters$beta_leisure = 0.132
+    parameters$beta_community = 0.044
+  }
+
+  # SARS-CoV-2 (R0 ~ 2.5)
+  if(archetype == "sars_cov_2") {
+    parameters$duration_exposed = 2
+    parameters$duration_infectious = 4
+    parameters$beta_household = 0.24
+    parameters$beta_workplace = 0.24
+    parameters$beta_school = 0.24
+    parameters$beta_leisure = 0.24
+    parameters$beta_community = 0.08
+  }
+
+  # Measles (R0 ~ 9)
+  if(archetype == "measles") {
+    parameters$duration_exposed = 8
+    parameters$duration_infectious = 5
+    parameters$beta_household = 1.26
+    parameters$beta_workplace = 1.26
+    parameters$beta_school = 1.26
+    parameters$beta_leisure = 1.26
+    parameters$beta_community = 0.42
   }
 
   # Check that all setting-specific betas are of length 1:

--- a/inst/blueprint_output1_May2024/partner_meeting_1_exemplar_simulations.R
+++ b/inst/blueprint_output1_May2024/partner_meeting_1_exemplar_simulations.R
@@ -39,35 +39,35 @@ library(gridExtra)
 # single value, or a vector of values for beta_community and will return the remaining setting-specific
 # beta values in the ratio
 
-generate_betas <- function(beta_community, household_ratio, school_ratio, workplace_ratio, leisure_ratio) {
-
-  # Use the community betas to generate the household, school, workplace, and leisure betas:
-  beta_household = household_ratio * beta_community
-  beta_school = school_ratio * beta_community
-  beta_workplace = workplace_ratio * beta_community
-  beta_leisure = leisure_ratio * beta_community
-
-  # Combine the betas into a dataframe:
-  betas <- data.frame(
-    beta_household = beta_household,
-    beta_school = beta_school,
-    beta_workplace = beta_workplace,
-    beta_leisure = beta_leisure,
-    beta_community = beta_community)
-
-  # Append columns giving the proportion of the total beta accounted for in each setting:
-  betas %>%
-    mutate(beta_total = beta_household + beta_school + beta_workplace + beta_leisure + beta_community) %>%
-    mutate(prop_household = beta_household / beta_total,
-           prop_school = beta_school / beta_total,
-           prop_workplace = beta_workplace / beta_total,
-           prop_leisure = beta_leisure / beta_total,
-           prop_community = beta_community / beta_total) -> betas
-
-  # Return the data frame of betas:
-  return(betas)
-
-}
+# generate_betas <- function(beta_community, household_ratio, school_ratio, workplace_ratio, leisure_ratio) {
+#
+#   # Use the community betas to generate the household, school, workplace, and leisure betas:
+#   beta_household = household_ratio * beta_community
+#   beta_school = school_ratio * beta_community
+#   beta_workplace = workplace_ratio * beta_community
+#   beta_leisure = leisure_ratio * beta_community
+#
+#   # Combine the betas into a dataframe:
+#   betas <- data.frame(
+#     beta_household = beta_household,
+#     beta_school = beta_school,
+#     beta_workplace = beta_workplace,
+#     beta_leisure = beta_leisure,
+#     beta_community = beta_community)
+#
+#   # Append columns giving the proportion of the total beta accounted for in each setting:
+#   betas %>%
+#     mutate(beta_total = beta_household + beta_school + beta_workplace + beta_leisure + beta_community) %>%
+#     mutate(prop_household = beta_household / beta_total,
+#            prop_school = beta_school / beta_total,
+#            prop_workplace = beta_workplace / beta_total,
+#            prop_leisure = beta_leisure / beta_total,
+#            prop_community = beta_community / beta_total) -> betas
+#
+#   # Return the data frame of betas:
+#   return(betas)
+#
+# }
 
 #----- 2) Matching Setting Betas to R0 Using Final Epidemic Size: 3:2:2:2:1 ------------------------
 
@@ -205,8 +205,10 @@ simulation_output %>%
 ##' beta_community = 0.1
 ##'
 
+rm(list = ls()); dev.off()
+
 # Use generate_betas() to create a dataframe of betas for all settings:
-betas <- generate_betas(beta_community = 0.062,
+betas <- generate_betas(beta_community = 0.42,
                         household_ratio = 3,
                         school_ratio = 3,
                         workplace_ratio = 3,
@@ -275,6 +277,8 @@ parameters_list$beta_community
 ##' 0.08                0.887
 ##' 0.081               0.9041
 ##' 0.085               0.9111
+##' 0.019               0.99
+##' 0.42(ish)           0.999
 
 ##' Betas that match R0s of interest:
 ##'
@@ -284,7 +288,7 @@ parameters_list$beta_community
 ##' 2       0.8       0.062             0.8001        t = 250
 ##' 2.5     0.89      0.08              0.893         t = 200
 ##' 3       0.94      0.097             0.9415        t = 175
-##'
+##' 9       0.9998    0.42(ish)         0.9984        t = 100
 
 #----- 4) Exemplar Model Runs: 3:2:2:2:1 -----------------------------------------------------------
 

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -4,7 +4,7 @@
 \alias{get_parameters}
 \title{Establish the list of model parameters}
 \usage{
-get_parameters(overrides = list())
+get_parameters(overrides = list(), archetype = "none")
 }
 \arguments{
 \item{overrides}{A named list of parameters values to be used instead of the defaults.
@@ -68,6 +68,8 @@ Far UVC Intervention Parameters:
 \item \code{far_uvc_household_efficacy}: : Efficacy of far UVC in the household setting (must be a numeric value between 0 and 1)
 \item \code{far_uvc_household_timestep}: The timestep on which far UVC is implemented in the household setting (must be a numeric value greater than or equal to 0)
 }}
+
+\item{archetype}{A text string indicating the pathogen archetype parameter set to load (default = "none", current options are flu, sars_cov_2, and measles)}
 }
 \description{
 This function creates a named list of model parameters which are to be used

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -40,8 +40,99 @@ test_that("get_parameters() successfully creates parameter list for endemic sett
 
 })
 
+test_that("get_parameters() errors when an unrecognised archetype is input", {
 
+  expect_error(get_parameters(archetype = "floo"),
+               "archetype not recognised")
 
+})
 
+test_that("get_parameters() assigns correct parameters for flu archetype", {
 
+  # Generate the parameter list for the fly archetype:
+  parameters_list <- get_parameters(archetype = "flu")
 
+  # We are expecting the following flu-specific parameters:
+  # duration_exposed = 1
+  # duration_infectious = 2
+  # beta_household = 0.132
+  # beta_school = 0.132
+  # beta_workplace = 0.132
+  # beta_leisure = 0.132
+  # beta_community = 0.044
+
+  # Check that the archetype-specific parameters match the expected values:
+  expect_identical(object = parameters_list$duration_exposed, expected = 1)
+  expect_identical(object = parameters_list$duration_infectious, expected = 2)
+  expect_identical(object = parameters_list$beta_household, expected = 0.132)
+  expect_identical(object = parameters_list$beta_school, expected = 0.132)
+  expect_identical(object = parameters_list$beta_workplace, expected = 0.132)
+  expect_identical(object = parameters_list$beta_leisure, expected = 0.132)
+  expect_identical(object = parameters_list$beta_community, expected = 0.044)
+
+})
+
+test_that("get_parameters() assigns correct parameters for SARS-CoV-2 archetype", {
+
+  # Generate the parameter list for the fly archetype:
+  parameters_list <- get_parameters(archetype = "sars_cov_2")
+
+  # We are expecting the following flu-specific parameters:
+  # duration_exposed = 2
+  # duration_infectious = 4
+  # beta_household = 0.24
+  # beta_school = 0.24
+  # beta_workplace = 0.24
+  # beta_leisure = 0.24
+  # beta_community = 0.08
+
+  # Check that the archetype-specific parameters match the expected values:
+  expect_identical(object = parameters_list$duration_exposed, expected = 2)
+  expect_identical(object = parameters_list$duration_infectious, expected = 4)
+  expect_identical(object = parameters_list$beta_household, expected = 0.24)
+  expect_identical(object = parameters_list$beta_school, expected = 0.24)
+  expect_identical(object = parameters_list$beta_workplace, expected = 0.24)
+  expect_identical(object = parameters_list$beta_leisure, expected = 0.24)
+  expect_identical(object = parameters_list$beta_community, expected = 0.08)
+
+})
+
+test_that("get_parameters() assigns correct parameters for measles archetype", {
+
+  # Generate the parameter list for the fly archetype:
+  parameters_list <- get_parameters(archetype = "measles")
+
+  # We are expecting the following flu-specific parameters:
+  # duration_exposed = 8
+  # duration_infectious = 5
+  # beta_household = 1.26
+  # beta_school = 1.26
+  # beta_workplace = 1.26
+  # beta_leisure = 1.26
+  # beta_community = 0.044
+
+  # Check that the archetype-specific parameters match the expected values:
+  expect_identical(object = parameters_list$duration_exposed, expected = 8)
+  expect_identical(object = parameters_list$duration_infectious, expected = 5)
+  expect_identical(object = parameters_list$beta_household, expected = 1.26)
+  expect_identical(object = parameters_list$beta_school, expected = 1.26)
+  expect_identical(object = parameters_list$beta_workplace, expected = 1.26)
+  expect_identical(object = parameters_list$beta_leisure, expected = 1.26)
+  expect_identical(object = parameters_list$beta_community, expected = 0.42)
+
+})
+
+test_that("run_simulation() works when a parameter archetype specified", {
+
+  # Generate the parameter list for the fly archetype:
+  parameters_list <- get_parameters(overrides = list(simulation_time = 3),
+                                    archetype = "flu")
+
+  # Run the simulation:
+  simulation_example <- run_simulation(parameters_list = parameters_list)
+
+  # Check that the output contains some expected column names and that it is a data.frame:
+  expect_true(all(c("S_count", "E_count", "I_count", "R_count") %in% names(simulation_example)))
+  expect_true(object = is.data.frame(simulation_example))
+
+})


### PR DESCRIPTION
In this PR I've added the capacity to load parameters for pathogen archetypes through the `get_parameters()` function. (`parameters.R`). The new argument has a default value of "none" and when this option is selected the parameter list returns the parameter list as usual with the specified `overrides`. When an archetype is selected (current options are `flu`, `sars_cov_2`, and `measles`, `get_parameters()` assigns values to each parameter as normal, then overwrites the values for the following parameters:

1. duration_exposed
2. duration_infectious
3. beta_household
4. beta_school
5. beta_workplace
6. beta_leisure
7. beta_community

The beta community values are selected to represent R0 values of approximately 1.5 for flu, 2.5 for sars_cov_2, and 9 for measles. There is also a test added to ensure that a recognised archetype has been specified and errors out if not. I have added some basic unit tests to check that the error catches erroneous archetype arguments as expected and that the parameter sets load as expected.

Happy for all suggestions and recommendations!
