### PR TITLE
Blueprint old edits

### DIFF
--- a/vignettes/blueprint.Rmd
+++ b/vignettes/blueprint.Rmd
@@ -175,8 +175,7 @@ table(number_leisure_places) |>
   labs(x = "Number of leisure venues attended in a week", y = "Count")
 ```
 
-(ref:leisure-venues) The number of leisure venues that each individual attends in a week.
-The minimum possible number of venues is zero, and maximum possible is seven.
+(ref:leisure-venues) The number of leisure venues that each individual attends in a week. The minimum possible number of venues is zero, and maximum possible is seven.
 
 ## Disease states and the infection process {#disease}
 
@@ -217,13 +216,12 @@ By altering the duration of acquired immunity to infection, the framework has th
 epidemic_plot <- exemplar_data |>
   filter(Setting == "Epidemic" & Intervention == "Baseline") |>
   filter(timestep %in% c(1:300)) |>
-  mutate(Percentage = Proportion * 100) |>
-  ggplot(aes(x = timestep, y = Percentage, colour = State)) +
+  ggplot(aes(x = timestep, y = Proportion, colour = State)) +
   geom_line(linewidth = 1.2) +
   theme_bw() +
   labs(x = "Days", y = "Percentage of Population", colour = "Disease State",
        title = "Epidemic Pathogen Model Simulation") +
-  scale_y_continuous(expand = c(0, 0), limits = c(0, 100)) +
+  scale_y_continuous(labels = scales::percent, expand = c(0, 0),, limits = c(0, 1)) +
   scale_x_continuous(expand = c(0, 0)) +
   scale_color_discrete(type = blueprint_colours) +
   theme(strip.background = element_blank(),
@@ -233,19 +231,18 @@ epidemic_plot <- exemplar_data |>
         legend.title = element_blank(),
         legend.position = "right",
         legend.background = element_blank(),
-        axis.line = element_line()) 
+        axis.line = element_line())
 
 # Plot the epidemic exemplar simulations:
 endemic_plot <- exemplar_data |>
   filter(Setting == "Endemic" & Intervention == "Baseline") |>
   filter(timestep %in% c(400:11000)) |>
-  mutate(Percentage = Proportion * 100) |>
-  ggplot(aes(x = timestep, y = Percentage, colour = State)) +
+  ggplot(aes(x = timestep, y = Proportion, colour = State)) +
   geom_line(linewidth = 1.2) +
   theme_bw() +
   labs(x = "Days", y = "Percentage of Population", colour = "Disease State",
        title = "Endemic Pathogen Model Simulation") +
-  scale_y_continuous(expand = c(0, 0), limits = c(0, 100)) +
+  scale_y_continuous(labels = scales::percent, expand = c(0, 0), limits = c(0, 1)) +
   scale_x_continuous(expand = c(0, 0)) +
   scale_color_discrete(type = blueprint_colours) +
   theme(strip.background = element_blank(),
@@ -258,9 +255,12 @@ endemic_plot <- exemplar_data |>
         axis.line = element_line()) 
 
 plot_legend <- cowplot::get_legend(endemic_plot)
-cowplot::plot_grid(epidemic_plot + theme(legend.position = "none"), 
-                   endemic_plot + theme(legend.position = "none"),
-                   plot_legend, nrow = 1, rel_widths = c(1, 1, 0.4))
+
+cowplot::plot_grid(
+  epidemic_plot + theme(legend.position = "none"), 
+  endemic_plot + theme(legend.position = "none"),
+  plot_legend, nrow = 1, rel_widths = c(1, 1, 0.4)
+)
 ```
 
 (ref:epidemic-endemic) Illustration of simulated epidemic and endemic pathogens.
@@ -295,10 +295,10 @@ data.frame(workplace_sizes) |>
     cols = c("Targeted", "Random"),
     names_to = "type",
     values_to = "chosen"
-  )|> 
+  ) |> 
   mutate(
     chosen2 = ifelse(chosen, "Yes", "No")
-  )|>
+  ) |>
   ggplot(aes(x = rank, y = log10(workplace_sizes) + 1, 
              col = chosen2, fill = chosen2)) +
   geom_bar(stat = "identity", alpha = 1, position = position_dodge()) +
@@ -349,12 +349,11 @@ Targeted far UVC provided an even greater reduction in the total number of peopl
 exemplar_data |>
   filter(Setting == "Epidemic") |>
   filter(timestep %in% c(1:1000)) |>
-  mutate(Percentage = Proportion * 100) |>
-  ggplot(aes(x = timestep, y = Percentage, colour = State)) +
+  ggplot(aes(x = timestep, y = Proportion, colour = State)) +
   geom_line(linewidth = 1.2) +
   theme_bw() +
   labs(x = "Days", y = "Percentage of Population", colour = "Disease State") +
-  scale_y_continuous(expand = c(0, 0), limits = c(0, 100)) +
+  scale_y_continuous(labels = scales::percent, expand = c(0, 0), limits = c(0, 1)) +
   scale_x_continuous(expand = c(0, 0)) +
   scale_color_discrete(type = blueprint_colours) +
   facet_grid(~Intervention) +
@@ -364,7 +363,7 @@ exemplar_data |>
         legend.title = element_blank(),
         legend.position = c(0.93, 0.85),
         legend.background = element_blank(),
-        axis.line = element_line()) 
+        axis.line = element_line())
 ```
 
 (ref:exemplar-epidemic) Illustration of the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of a theoretical pathogen when full and lasting immunity to infection is acquired by infected individuals (i.e. the pathogen induces a single epidemic).
@@ -383,12 +382,11 @@ Again, targeting far UVC deployment provided additional benefits to pathogen sup
 exemplar_data |>
   filter(Setting == "Endemic") |>
   filter(timestep %in% c(400:1000)) |>
-  mutate(Percentage = Proportion * 100) |>
-  ggplot(aes(x = timestep, y = Percentage, colour = State)) +
+  ggplot(aes(x = timestep, y = Proportion, colour = State)) +
   geom_line(linewidth = 1.2) +
   theme_bw() +
   labs(x = "Days", y = "Percentage of Population", colour = "Disease State") +
-  scale_y_continuous(expand = c(0, 0), limits = c(0, 100)) +
+  scale_y_continuous(labels = scales::percent, expand = c(0, 0), limits = c(0, 1)) +
   scale_x_continuous(expand = c(0, 0), breaks = c(400, 600, 800, 100), labels = c(0, 200, 400, 600)) +
   scale_color_discrete(type = blueprint_colours) +
   facet_grid(~Intervention) +
@@ -419,34 +417,34 @@ For low transmission intensities ($R_0 \leq 1.5$), very high levels of far UVC c
 ```{r sweep-R0-coverage, fig.cap="(ref:sweep-R0-coverage)"}
 coverage_over_time <- parameter_sweep_data |>
   filter(efficacy == 0.8, coverage <= 1) |>
-  ggplot(aes(x = 100 * coverage, y = 100 * final_size, col = factor(R0))) +
+  ggplot(aes(x = coverage, y = final_size, col = factor(R0))) +
   geom_line() +
+  scale_x_continuous(labels = scales::percent, limits = c(0, 1)) +
+  scale_y_continuous(labels = scales::percent, limits = c(0, 1)) +
   facet_grid(. ~ Coverage_Strategy) +
   theme_bw() +
   theme(strip.background = element_rect(fill = "white", colour = "black")) +
-  labs(x = "Coverage %", y = "Epidemic Final Size", colour = "R0")
+  labs(x = "Far UVC Coverage", y = "Epidemic Final Size", colour = "R0")
 
-heatmap_contained <- parameter_sweep_data |>
+coverage_heatmap_contained <- parameter_sweep_data |>
   filter(efficacy == 0.8, coverage <= 1) |>
-  ggplot(aes(y = factor(R0), x = 100 * coverage, fill = 100 * final_size)) +
+  ggplot(aes(y = factor(R0), x = coverage, fill = final_size)) +
   geom_tile(colour = "black") +
-  scale_fill_viridis_c(option = "rocket", limits = c(0, 100), begin = 0,
-                       end = 1, name = "Proportion\nContained", direction = -1) +
-    scale_x_continuous(breaks = c(0, 20, 40, 60, 80, 100),
-                       labels = c(0, 20, 40, 60, 80, 100)) +
-    facet_grid(. ~ Coverage_Strategy) +
-    labs(y = "R0", x = "farUVC Coverage (%)") +
-    theme(axis.text = element_text(angle = 0),
-          plot.title = element_text(hjust = 0.5, size = 20, face = "bold"),
-          legend.title = element_text(size = 12),
-          legend.text = element_text(size = 12),
-          legend.position = "right",
-          strip.background = element_rect(fill = "white", colour = "black"),
-          panel.border = element_rect(linetype = "solid", fill = NA, linewidth = 0.5)) +
-    coord_cartesian(expand = FALSE)
+  scale_fill_viridis_c(
+    option = "rocket", limits = c(0, 1), begin = 0, end = 1,
+    name = "Proportion\nContained", direction = -1, labels = scales::percent
+  ) +
+  scale_x_continuous(breaks = c(0, 0.2, 0.4, 0.6, 0.8, 1), labels = scales::percent) +
+  facet_grid(. ~ Coverage_Strategy) +
+  labs(y = "R0", x = "Far UVC Coverage") +
+  theme(axis.text = element_text(angle = 0),
+        legend.position = "right",
+        strip.background = element_rect(fill = "white", colour = "black"),
+        panel.border = element_rect(linetype = "solid", fill = NA, linewidth = 0.5)) +
+  coord_cartesian(expand = FALSE)
 
 # Align the figures in both directions
-cowplot::plot_grid(coverage_over_time, heatmap_contained, nrow = 2,
+cowplot::plot_grid(coverage_over_time, coverage_heatmap_contained, nrow = 2,
                    align = "hv", axis = "lr", rel_heights = c(1, 2))
 ```
 
@@ -455,36 +453,36 @@ cowplot::plot_grid(coverage_over_time, heatmap_contained, nrow = 2,
 ### Sensitivity analysis of $R_0$ and far UVC efficacy
 
 ```{r sweep-R0-efficacy, fig.cap="(ref:sweep-R0-efficacy)"}
-coverage_over_time <- parameter_sweep_data |>
+efficacy_over_time <- parameter_sweep_data |>
   filter(coverage > 0.7 & coverage < 1) |>
-  ggplot(aes(x = 100 * efficacy, y = 100 * final_size, col = factor(R0))) +
+  ggplot(aes(x = efficacy, y = final_size, col = factor(R0))) +
   geom_line() +
+  scale_x_continuous(labels = scales::percent, limits = c(0, 1)) +
+  scale_y_continuous(labels = scales::percent, limits = c(0, 1)) +
   facet_grid(. ~ Coverage_Strategy) +
   theme_bw() +
-  theme(strip.background = element_rect(fill="white", colour = "black")) +
-  labs(x = "Efficacy %", y = "Epidemic Final Size", colour = "R0")
+  theme(strip.background = element_rect(fill = "white", colour = "black")) +
+  labs(x = "Far UVC Efficacy", y = "Epidemic Final Size", colour = "R0")
 
-heatmap_contained <- parameter_sweep_data |>
+efficacy_heatmap_contained <- parameter_sweep_data |>
   filter(coverage > 0.7 & coverage < 1) |>
-  ggplot(aes(y = factor(R0), x = 100 * efficacy, fill = 100 * final_size)) +
+  ggplot(aes(y = factor(R0), x = efficacy, fill = final_size)) +
   geom_tile(colour = "black") +
-  scale_fill_viridis_c(option = "mako", limits = c(0, 100),begin = 0, end = 1,
-                       name = "Proportion\nContained", direction = -1) +
-    scale_x_continuous(breaks = c(0, 20, 40, 60, 80, 100),
-                       labels = c(0, 20, 40, 60, 80, 100)) +
-    facet_grid(. ~ Coverage_Strategy) +
-    labs(y = "R0", x = "farUVC Efficacy (%)") +
-    theme(axis.text = element_text(angle = 0),
-          plot.title = element_text(hjust = 0.5, size = 20, face = "bold"),
-          legend.title = element_text(size = 12),
-          legend.text = element_text(size = 12),
-          legend.position = "right",
-          strip.background = element_rect(fill = "white", colour = "black"),
-          panel.border = element_rect(linetype = "solid", fill = NA, linewidth = 0.5)) +
-    coord_cartesian(expand = FALSE)
+  scale_fill_viridis_c(
+    option = "mako", limits = c(0, 1),begin = 0, end = 1,
+    name = "Proportion\nContained", direction = -1, labels = scales::percent
+  ) +
+  scale_x_continuous(breaks = c(0, 0.2, 0.4, 0.6, 0.8, 1), labels = scales::percent) +
+  facet_grid(. ~ Coverage_Strategy) +
+  labs(y = "R0", x = "Far UVC Efficacy") +
+  theme(axis.text = element_text(angle = 0),
+        legend.position = "right",
+        strip.background = element_rect(fill = "white", colour = "black"),
+        panel.border = element_rect(linetype = "solid", fill = NA, linewidth = 0.5)) +
+  coord_cartesian(expand = FALSE)
 
 # Align the figures in both directions
-cowplot::plot_grid(coverage_over_time, heatmap_contained, nrow = 2,
+cowplot::plot_grid(efficacy_over_time, efficacy_heatmap_contained, nrow = 2,
                    align = "hv", axis = "lr", rel_heights = c(1, 2))
 ```
 

--- a/vignettes/blueprint.Rmd
+++ b/vignettes/blueprint.Rmd
@@ -92,9 +92,6 @@ Specifically, we sample with replacement from this data to generate households a
 Household assignment is **static** - for each individual, the specific household they are assigned to is fixed and does not change across the course of a single simulation.
 They stay in the same household each day.
 
-(ref:household-size) The distribution of household sizes.
-Households with two individuals are the most common, followed by single individual households.
-
 ```{r household-size, fig.cap="(ref:household-size)"}
 households <- variables$variables_list$household$get_categories()
 household_sizes <- purrr::map_vec(households, function(x) variables$variables_list$household$get_size_of(values = x))
@@ -106,7 +103,7 @@ table(household_sizes) |>
   labs(x = "Number of individuals in the household", y = "Count")
 ```
 
-(ref:age) Age group sizes follow from the household sampling procedure.
+(ref:household-size) The distribution of household sizes. Households with two individuals are the most common, followed by single individual households.
 
 ```{r age, fig.cap="(ref:age)"}
 data.frame(age_classes, age_class_counts) |>
@@ -117,14 +114,14 @@ data.frame(age_classes, age_class_counts) |>
   coord_flip()
 ```
 
+(ref:age) Age group sizes follow from the household sampling procedure.
+
 2.  **Schools** All children are assumed to attend school.
 The number of students in each school (Figure \@ref(fig:school-size)) is sampled from the 2022/2023 census of schools in the UK [@school2023], with children then assigned randomly to each school.
 A small number of adults also attend schools (rather than workplaces) to reflect educational staff such as teachers.
 For each 20 students, there is one adult teacher who works at the school (this is based on UK Office of National Statistics Data).
 School assignment is **static**: for each individual, the particular school they are assigned to is fixed and does not change across the course of a single simulation.
 They visit the same school each day.
-
-(ref:school-size) The distribution of school sizes.
 
 ```{r school-size, fig.cap="(ref:school-size)"}
 schools <- variables$variables_list$school$get_categories()
@@ -138,14 +135,13 @@ data.frame(school_sizes) |>
   scale_y_continuous(limits = c(0, NA))
 ```
 
+(ref:school-size) The distribution of school sizes.
+
 3.  **Workplaces** All adults (who are not teachers) are assumed to attend workplaces.
 The number of employees in each workplace (Figure \@ref(fig:workplace-size)) is sampled from an offset truncated power statistical distribution, based on that of @ferguson2005strategies which in turn is based on data from the United States of America.
 Adults are assigned randomly to each of these workplaces.
 Workplace assignment is **static**: for each individual, the particular workplace they are assigned to is fixed and does not change across the course of a single simulation.
 They visit the same workplace each day.
-
-(ref:workplace-size) The distribution of workplace sizes.
-Here, size is shown on a logarithmic scale.
 
 ```{r workplace-size, fig.cap="(ref:workplace-size)"}
 workplaces <- variables$variables_list$workplace$get_categories()
@@ -160,14 +156,13 @@ data.frame(workplace_sizes) |>
   labs(x = "Workplace Size (Number of Individuals)", y = "Count")
 ```
 
+(ref:workplace-size) The distribution of workplace sizes. Here, size is shown on a logarithmic scale.
+
 4.  **Leisure venues** All individuals (children, adults, and elderly people) are eligible to attend leisure venues.
 Leisure venue sizes are sampled from a negative binomial distribution, which determines their maximum occupancy.
 Leisure venue assignment is **dynamic**: for each individual, the particular leisure venue they are assigned to is dynamic and changes across the course of a single simulation.
 They visit a different leisure venue each day (and sometimes do not visit any leisure venues on a given day), with the number of leisure venues visited by each individual per week (Figure \@ref(fig:leisure-venues)) sampled from a Poisson distribution, capped at seven corresponding to one leisure visit each day.
 The particular leisure venue they visit is drawn from a short individual-specific list of potential leisure venues that is determined randomly.
-
-(ref:leisure-venues) The number of leisure venues that each individual attends in a week.
-The minimum possible number of venues is zero, and maximum possible is seven.
 
 ```{r leisure-venues, fig.cap="(ref:leisure-venues)"}
 leisure_places <- variables$variables_list$leisure$get_values()
@@ -179,6 +174,9 @@ table(number_leisure_places) |>
   geom_col() +
   labs(x = "Number of leisure venues attended in a week", y = "Count")
 ```
+
+(ref:leisure-venues) The number of leisure venues that each individual attends in a week.
+The minimum possible number of venues is zero, and maximum possible is seven.
 
 ## Disease states and the infection process {#disease}
 
@@ -192,11 +190,9 @@ Individuals exist in one of four different disease states:
 At any timepoint, each individual is either susceptible, exposed, infectious, or recovered.
 Individuals are infected (S -\> E) after spending time in the same location as infectious individuals.
 For each individual we calculate a location-specific force of infection, which determines the probability they are infected in a given timestep. Specifically, the force of infection experienced by individual $i$ in location $m$ at time $t$ is calculated as follows:
-
 $$
 \lambda_{i,m}(t) = \frac{\beta_{m} I_m(t)}{N_m}
 $$
-
 where $I_m(t)$ are the number of infectious individuals in location $m$ at time $t$, $N_m$ are the total number of individuals visiting location $m$ at time $t$ and $\beta_m$ is a location specific (i.e. workplace, school, household, leisure-venue) transmissibility parameter that integrates consideration of both the ***amount of time spent in a location*** and ***the inherent "riskiness"*** **of a location** (i.e. how receptive to onwards transmission it is).
 Currently within the model, each setting type has a specific $\beta$ (i.e. $\beta_{W}$,$\beta_{S}$ , $\beta_{H}$, $\beta_{L}$ respectively) and all individual locations within a setting type (e.g. all schools) have the same $\beta$ (though this could be changed in future versions).
 
@@ -216,10 +212,7 @@ Infectious individuals recover after some delay (the *duration of infectiousness
 After recovering, individuals can then return to being susceptible (reflecting the loss of acquired immunity to infection), again after some delay.
 By altering the duration of acquired immunity to infection, the framework has the capacity to simulate both epidemic (those producing a single "epidemic wave" before dying out) and endemic (those which are constantly present in the population) pathogens (Figure \@ref(fig:epidemic-endemic)).
 
-(ref:epidemic-endemic) Illustration of simulated epidemic and endemic pathogens.
-
 ```{r epidemic-endemic, fig.cap="(ref:epidemic-endemic)"}
-
 # Plot the epidemic exemplar simulations:
 epidemic_plot <- exemplar_data |>
   filter(Setting == "Epidemic" & Intervention == "Baseline") |>
@@ -270,6 +263,8 @@ cowplot::plot_grid(epidemic_plot + theme(legend.position = "none"),
                    plot_legend, nrow = 1, rel_widths = c(1, 1, 0.4))
 ```
 
+(ref:epidemic-endemic) Illustration of simulated epidemic and endemic pathogens.
+
 ## Modelling far UVC
 
 Far UVC interventions can be installed in each of the four setting types, in any combination (i.e. in either one, two, three, or all four setting types).
@@ -287,8 +282,6 @@ Given a certain level of coverage (e.g. 20%), the settings with far UVC installe
 - **Targeted:** Locations for far UVC to be installed are chosen in order of size, with the largest 20% of locations selected to receive far UVC.
 
 Figure \@ref(fig:uvc) provides an example illustrating the difference between these two strategies as applied to the schools setting type.
-
-(ref:uvc) Illustration of the targeted and random strategies for the workplace setting type.
 
 ```{r uvc, fig.cap="(ref:uvc)"}
 data.frame(workplace_sizes) |>
@@ -320,6 +313,8 @@ data.frame(workplace_sizes) |>
   )
 ```
 
+(ref:uvc) Illustration of the targeted and random strategies for the workplace setting type.
+
 # Illustrative simulations of far UVC
 
 What follows is a demonstration of the types of model outputs that `helios` can generate, and how these outputs can be presented graphically.
@@ -340,7 +335,7 @@ These comparisons were performed for both epidemic and endemic pathogens. For ep
 We assumed far UVC efficacy was sufficient to reduce transmission intensity by 75%, and that coverage of far UVC (i.e. the proportion of locations with far UVC installed) was 50%.
 Further, we assume a 30%\|30%\|30%\|10% split in where transmission takes place (households, workplace/school, leisure venue and in the community, respectively).
 
-### Epidemic Pathogen Simulation
+### Epidemic pathogen simulation
 
 Figure \@ref(fig:exemplar-epidemic) shows the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of an epidemic pathogen.
 Random indicates that far UVC was assigned to a random 50% of school, workplace and leisure locations.
@@ -494,5 +489,33 @@ cowplot::plot_grid(coverage_over_time, heatmap_contained, nrow = 2,
 ```
 
 (ref:sweep-R0-efficacy) The effect of $R_0$ and far UVC efficacy, under random and targeted far UVC deployment, on the proportion of the population that a pathogen infects assuming a far UVC coverage of 80% is achieved.
+
+## Assessing how various far UVC parameters shape another outcome
+
+We considered two pathogen archetypes, SARS-CoV-2 and influenza.
+The properties of SARS-CoV-2 were as follows.
+The properties of influenze were as follows.
+For each pathogen archetype, we considered the effect of far UVC efficacy and far UVC coverage on another outcome.
+We varied far UVC efficacy in the following range.
+We varied far UVC coverage in the following range with the following settings.
+The results are presented in Figure \@ref(fig:placeholder-1) and Figure \@ref(fig:placeholder-2).
+
+```{r placeholder-1, fig.cap="(ref:placeholder-1)"}
+data.frame(x = 1:5, y = 1:5) |>
+  ggplot(aes(x = x, y = y)) +
+  geom_point() +
+  theme_minimal()
+```
+
+(ref:placeholder-1) Placeholder one.
+
+```{r placeholder-2, fig.cap="(ref:placeholder-2)"}
+data.frame(x = 1:5, y = 1:5) |>
+  ggplot(aes(x = x, y = y)) +
+  geom_point() +
+  theme_minimal()
+```
+
+(ref:placeholder-2) Placeholder two.
 
 # Bibliography {.unnumbered}

--- a/vignettes/blueprint.Rmd
+++ b/vignettes/blueprint.Rmd
@@ -48,7 +48,7 @@ The aim of this document is to introduce `helios`, an individual-based modelling
 `helios` explicitly represents the built environment and how individuals spend their time in this built environment, as well as modifications to that built environment that reduce the probability of pathogen transmission occurring (such as far UVC).
 The package can be used to quantify the impact of installing far UVC interventions on public health outcomes, such as infections.
 
-# Aim of this Document
+# Aim of this document
 
 The aim of this document is to introduce you to the `helios` modelling framework and the types of results it can currently produce.
 Our hope is that this document will serve as a jumping off point to discuss:
@@ -180,7 +180,7 @@ table(number_leisure_places) |>
   labs(x = "Number of leisure venues attended in a week", y = "Count")
 ```
 
-## Disease States & The Infection Process {#disease}
+## Disease states and the infection process {#disease}
 
 Individuals exist in one of four different disease states:
 
@@ -270,7 +270,7 @@ cowplot::plot_grid(epidemic_plot + theme(legend.position = "none"),
                    plot_legend, nrow = 1, rel_widths = c(1, 1, 0.4))
 ```
 
-## Modelling Far UVC
+## Modelling far UVC
 
 Far UVC interventions can be installed in each of the four setting types, in any combination (i.e. in either one, two, three, or all four setting types).
 We model the efficacy of far UVC as the reduction in the force of infection an individual experiences in a location where it is installed. Specifically, the force of infection experienced by individual $i$ in location $m$ at time $t$ where far UVC is installed is calculated as follows:
@@ -320,7 +320,7 @@ data.frame(workplace_sizes) |>
   )
 ```
 
-# Illustrative Simulations of Far UVC
+# Illustrative simulations of far UVC
 
 What follows is a demonstration of the types of model outputs that `helios` can generate, and how these outputs can be presented graphically.
 To do this, we have carried out two sets of analyses using the modelling framework to investigate the following:
@@ -365,7 +365,7 @@ exemplar_data |>
   facet_grid(~Intervention) +
   theme(strip.background = element_blank(),
         strip.text = element_text(colour = "#03113E", size = 12),
-        panel.border=element_blank(),
+        panel.border = element_blank(),
         legend.title = element_blank(),
         legend.position = c(0.93, 0.85),
         legend.background = element_blank(),
@@ -403,8 +403,7 @@ exemplar_data |>
         legend.title = element_blank(),
         legend.position = c(0.93, 0.5),
         legend.background = element_blank(),
-        axis.line = element_line()) 
-
+        axis.line = element_line())
 ```
 
 (ref:exemplar-endemic) Illustration of the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of a theoretical pathogen on the disease state dynamics of a theoretical pathogen, when the immunity acquired during infection wanes over time (i.e. the pathogen exists in an endemic state).
@@ -420,7 +419,7 @@ Figures \@ref(fig:sweep-R0-coverage) and \@ref(fig:sweep-R0-efficacy) illustrate
 
 For low transmission intensities ($R_0 \leq 1.5$), very high levels of far UVC coverage and/or prevented the epidemic from occurring (final epidemic size \~0%). Across the majority of combinations of $R_0$, far UVC coverage, and far UVC efficacy, targeting the deployment of far UVC to the most populous settings achieved a greater reduction in final epidemic size.
 
-### Sensitivity Analysis of $R_0$ and far UVC Coverage
+### Sensitivity analysis of $R_0$ and far UVC coverage
 
 ```{r sweep-R0-coverage, fig.cap="(ref:sweep-R0-coverage)"}
 coverage_over_time <- parameter_sweep_data |>
@@ -458,7 +457,7 @@ cowplot::plot_grid(coverage_over_time, heatmap_contained, nrow = 2,
 
 (ref:sweep-R0-coverage) The effect of $R_0$ and far UVC efficacy, under random and targeted far UVC deployment, on the proportion of the population that a pathogen infects assuming a far UVC efficacy of 80%.
 
-### Sensitivity Analysis of $R_0$ and far UVC Efficacy
+### Sensitivity analysis of $R_0$ and far UVC efficacy
 
 ```{r sweep-R0-efficacy, fig.cap="(ref:sweep-R0-efficacy)"}
 coverage_over_time <- parameter_sweep_data |>

--- a/vignettes/blueprint.Rmd
+++ b/vignettes/blueprint.Rmd
@@ -488,32 +488,4 @@ cowplot::plot_grid(efficacy_over_time, efficacy_heatmap_contained, nrow = 2,
 
 (ref:sweep-R0-efficacy) The effect of $R_0$ and far UVC efficacy, under random and targeted far UVC deployment, on the proportion of the population that a pathogen infects assuming a far UVC coverage of 80% is achieved.
 
-## Assessing how various far UVC parameters shape another outcome
-
-We considered two pathogen archetypes, SARS-CoV-2 and influenza.
-The properties of SARS-CoV-2 were as follows.
-The properties of influenze were as follows.
-For each pathogen archetype, we considered the effect of far UVC efficacy and far UVC coverage on another outcome.
-We varied far UVC efficacy in the following range.
-We varied far UVC coverage in the following range with the following settings.
-The results are presented in Figure \@ref(fig:placeholder-1) and Figure \@ref(fig:placeholder-2).
-
-```{r placeholder-1, fig.cap="(ref:placeholder-1)"}
-data.frame(x = 1:5, y = 1:5) |>
-  ggplot(aes(x = x, y = y)) +
-  geom_point() +
-  theme_minimal()
-```
-
-(ref:placeholder-1) Placeholder one.
-
-```{r placeholder-2, fig.cap="(ref:placeholder-2)"}
-data.frame(x = 1:5, y = 1:5) |>
-  ggplot(aes(x = x, y = y)) +
-  geom_point() +
-  theme_minimal()
-```
-
-(ref:placeholder-2) Placeholder two.
-
 # Bibliography {.unnumbered}

--- a/vignettes/blueprint.Rmd
+++ b/vignettes/blueprint.Rmd
@@ -44,16 +44,20 @@ parameter_sweep_data <- readRDS("./parameter_sweep_data.rds")
 
 # Overview
 
-The aim of this document is to introduce `helios`, an individual-based modelling framework for exploring and evaluating the potential of far UVC to control respiratory pathogens. `helios` explicitly represents the built environment and how individuals spend their time in this built environment, as well as modifications to that built environment that reduce the probability of pathogen transmission occurring (such as far UVC). The package can be used to quantify the impact of installing far UVC interventions on public health outcomes, such as infections.
+The aim of this document is to introduce `helios`, an individual-based modelling framework for exploring and evaluating the potential of far UVC to control respiratory pathogens.
+`helios` explicitly represents the built environment and how individuals spend their time in this built environment, as well as modifications to that built environment that reduce the probability of pathogen transmission occurring (such as far UVC).
+The package can be used to quantify the impact of installing far UVC interventions on public health outcomes, such as infections.
 
 # Aim of this Document
 
-The aim of this document is to introduce you to the `helios` modelling framework and the types of results it can currently produce. Our hope is that this document will serve as a jumping off point to discuss:
+The aim of this document is to introduce you to the `helios` modelling framework and the types of results it can currently produce.
+Our hope is that this document will serve as a jumping off point to discuss:
 
-1.  Any additions to the model that will be required to answer priority questions for Blueprint Biosecurity.
-2.  The types of results that can be generated to answer those priority questions.
+1. Any additions to the model that will be required to answer priority questions for Blueprint Biosecurity.
+2. The types of results that can be generated to answer those priority questions.
 
-We note here that the results presented are purely **examples** of the types of results this framework can produce. Model parameterisation is underway but incomplete, and will require further time and development to get to a point where the results should be trusted.
+We note here that the results presented are purely **examples** of the types of results this framework can produce.
+Model parameterisation is underway but incomplete, and will require further time and development to get to a point where the results should be trusted.
 
 # Model description
 
@@ -66,19 +70,30 @@ age_classes <- variables$variables_list$age_class$get_categories()
 age_class_counts <- purrr::map_vec(age_classes, function(x) variables$variables_list$age_class$get_size_of(values = x))
 ```
 
-The model implemented in `helios` has a fixed population of individuals, who are each assigned one of three age-groups (children, adults, elderly). Each individual is therefore either a child, an adult, or an elderly person. Figure \@ref(fig:age) shows the proportion in each age group from an example population of size `r human_population` individuals. We do not currently explicitly model demographic changes in the model and so we assume that no aging between the age-groups (e.g. child -\> adult) occurs during the simulation.
+The model implemented in `helios` has a fixed population of individuals, who are each assigned one of three age-groups (children, adults, elderly).
+Each individual is therefore either a child, an adult, or an elderly person.
+Figure \@ref(fig:age) shows the proportion in each age group from an example population of size `r human_population` individuals.
+We do not currently explicitly model demographic changes in the model and so we assume that no aging between the age-groups (e.g. child -\> adult) occurs during the simulation.
 
-During each day, individuals visit particular locations (Section \@ref(locations)) and mix with other individuals who are also visiting those same locations at the same time. We model 4 location types: **Households**, **Schools**, **Workplaces**, and **Leisure** **Venues**. Individuals are assigned to each location in a way that depends on their age-group (e.g. children are assigned to schools, adults are assigned to workplaces), with assignment to a **specific** location within a particular type (e.g. School #7) performed stochastically (see \@ref(locations) below).
+During each day, individuals visit particular locations (Section \@ref(locations)) and mix with other individuals who are also visiting those same locations at the same time.
+We model four setting types: **households**, **schools**, **workplaces**, and **leisure venues**.
+Individuals are assigned to each location in a way that depends on their age-group (e.g. children are assigned to schools, adults are assigned to workplaces), with assignment to a **specific** location within a particular setting type (e.g. school #7) performed stochastically (see \@ref(locations) below).
 
-It is during these visits to the same location that pathogen transmission can occur between two individuals - this process is stochastic and occurs only between individuals visiting the same location. See Section \@ref(disease) for further details.
+It is during these visits to the same location that pathogen transmission can occur between two individuals.
+This process is stochastic and occurs only between individuals visiting the same location.
+See Section \@ref(disease) for further details.
 
 ## Locations {#locations}
 
-Below we provide detail on how individuals are assigned to each Location Type.
+Below we provide detail on how individuals are assigned to locations within each setting type.
 
-1.  **Households:** The number of individuals in each household (Figure \@ref(fig:household-size)) and the age-composition of individuals (Figure \@ref(fig:age)) within each household are determined using data on household-age composition data from the 2011 Office for National Statistics survey in the United Kingdom (UK), following @hinch2021openabm. Specifically, we sample with replacement from this data to generate households and then populate those households with individuals. Household assignment is **static** - for each individual, the specific household they are assigned to is fixed and does not change across the course of a single simulation. They stay in the same household each day.
+1.  **Households:** The number of individuals in each household (Figure \@ref(fig:household-size)) and the age-composition of individuals (Figure \@ref(fig:age)) within each household are determined using data on household-age composition data from the 2011 Office for National Statistics survey in the United Kingdom (UK), following @hinch2021openabm.
+Specifically, we sample with replacement from this data to generate households and then populate those households with individuals.
+Household assignment is **static** - for each individual, the specific household they are assigned to is fixed and does not change across the course of a single simulation.
+They stay in the same household each day.
 
-(ref:household-size) The distribution of household sizes. Households with two individuals are the most common, followed by single individual households.
+(ref:household-size) The distribution of household sizes.
+Households with two individuals are the most common, followed by single individual households.
 
 ```{r household-size, fig.cap="(ref:household-size)"}
 households <- variables$variables_list$household$get_categories()
@@ -102,7 +117,12 @@ data.frame(age_classes, age_class_counts) |>
   coord_flip()
 ```
 
-2.  **Schools** All children are assumed to attend school. The number of students in each school (Figure \@ref(fig:school-size)) is sampled from the 2022/2023 census of schools in the UK [@school2023], with children then assigned randomly to each school. A small number of adults also attend schools (rather than workplaces) to reflect educational staff such as teachers. For each 20 students, there is one adult teacher who works at the school (this is based on UK Office of National Statistics Data). School assignment is **static** - for each individual, the particular school they are assigned to is fixed and does not change across the course of a single simulation. They visit the same school each day.
+2.  **Schools** All children are assumed to attend school.
+The number of students in each school (Figure \@ref(fig:school-size)) is sampled from the 2022/2023 census of schools in the UK [@school2023], with children then assigned randomly to each school.
+A small number of adults also attend schools (rather than workplaces) to reflect educational staff such as teachers.
+For each 20 students, there is one adult teacher who works at the school (this is based on UK Office of National Statistics Data).
+School assignment is **static**: for each individual, the particular school they are assigned to is fixed and does not change across the course of a single simulation.
+They visit the same school each day.
 
 (ref:school-size) The distribution of school sizes.
 
@@ -118,9 +138,14 @@ data.frame(school_sizes) |>
   scale_y_continuous(limits = c(0, NA))
 ```
 
-3.  **Workplaces** All adults (who are not teachers) are assumed to attend workplaces. The number of employees in each workplace (Figure \@ref(fig:workplace-size)) is sampled from an offset truncated power statistical distribution, based on that of @ferguson2005strategies which in turn is based on data from the United States of America. Adults are assigned randomly to each of these workplaces. Workplace assignment is **static** - for each individual, the particular workplace they are assigned to is fixed and does not change across the course of a single simulation. They visit the same workplace each day.
+3.  **Workplaces** All adults (who are not teachers) are assumed to attend workplaces.
+The number of employees in each workplace (Figure \@ref(fig:workplace-size)) is sampled from an offset truncated power statistical distribution, based on that of @ferguson2005strategies which in turn is based on data from the United States of America.
+Adults are assigned randomly to each of these workplaces.
+Workplace assignment is **static**: for each individual, the particular workplace they are assigned to is fixed and does not change across the course of a single simulation.
+They visit the same workplace each day.
 
-(ref:workplace-size) The distribution of workplace sizes. Here, size is shown on a logarithimic scale.
+(ref:workplace-size) The distribution of workplace sizes.
+Here, size is shown on a logarithmic scale.
 
 ```{r workplace-size, fig.cap="(ref:workplace-size)"}
 workplaces <- variables$variables_list$workplace$get_categories()
@@ -135,9 +160,14 @@ data.frame(workplace_sizes) |>
   labs(x = "Workplace Size (Number of Individuals)", y = "Count")
 ```
 
-4.  **Leisure venues** All individuals (children, adults, and elderly people) are eligible to attend leisure venues. Leisure venue sizes are sampled from a negative binomial distribution, which determines their maximum occupancy. Leisure venue assignment is **dynamic** - for each individual, the particular leisure venue they are assigned to is dynamic and changes across the course of a single simulation. They visit a different leisure venue each day (and sometimes do not visit any leisure venues on a given day), with the number of leisure venues visited by each individual per week (Figure \@ref(fig:leisure-venues)) sampled from a Poisson distribution, capped at seven corresponding to one leisure visit each day. The particular leisure venue they visit is drawn from a short individual-specific list of potential leisure venues that is determined randomly.
+4.  **Leisure venues** All individuals (children, adults, and elderly people) are eligible to attend leisure venues.
+Leisure venue sizes are sampled from a negative binomial distribution, which determines their maximum occupancy.
+Leisure venue assignment is **dynamic**: for each individual, the particular leisure venue they are assigned to is dynamic and changes across the course of a single simulation.
+They visit a different leisure venue each day (and sometimes do not visit any leisure venues on a given day), with the number of leisure venues visited by each individual per week (Figure \@ref(fig:leisure-venues)) sampled from a Poisson distribution, capped at seven corresponding to one leisure visit each day.
+The particular leisure venue they visit is drawn from a short individual-specific list of potential leisure venues that is determined randomly.
 
-(ref:leisure-venues) The number of leisure venues that each individual attends in a week. The minimum possible number of venues is zero, and maximum possible is seven.
+(ref:leisure-venues) The number of leisure venues that each individual attends in a week.
+The minimum possible number of venues is zero, and maximum possible is seven.
 
 ```{r leisure-venues, fig.cap="(ref:leisure-venues)"}
 leisure_places <- variables$variables_list$leisure$get_values()
@@ -154,33 +184,37 @@ table(number_leisure_places) |>
 
 Individuals exist in one of four different disease states:
 
--   **Susceptible:** They are susceptible to infection by the pathogen.
+- **Susceptible:** They are susceptible to infection by the pathogen.
+- **Exposed:** They have been infected but are not currently infectious (often known as the pathogen's *"incubation period"*).
+- **Infectious:** They are infectious and can infect other individuals.
+- **Recovered:** They are no longer infectious and are immune to future infection.
 
--   **Exposed:** They have been infected but are not currently infectious (often known as the pathogen's *"incubation period"*).
-
--   **Infectious:** They are infectious and can infect other individuals.
-
--   **Recovered:** They are no longer infectious and are immune to future infection.
-
-At any timepoint, each individual is either susceptible, exposed, infectious, or recovered. Individuals are infected (S -\> E) after spending time in the same location as infectious individuals. For each individual we calculate a location-specific force of infection, which determines the probability they are infected in a given timestep. Specifically, the force of infection experienced by individual $i$ in Location $m$ at time $t$ is calculated as follows:
+At any timepoint, each individual is either susceptible, exposed, infectious, or recovered.
+Individuals are infected (S -\> E) after spending time in the same location as infectious individuals.
+For each individual we calculate a location-specific force of infection, which determines the probability they are infected in a given timestep. Specifically, the force of infection experienced by individual $i$ in location $m$ at time $t$ is calculated as follows:
 
 $$
 \lambda_{i,m}(t) = \frac{\beta_{m} I_m(t)}{N_m}
 $$
 
-where $I_m(t)$ are the number of infectious individuals in Location $m$ at time $t$ , $N_m$ are the total number of individuals visiting Location $m$ at time $t$ and $\beta_m$ is a location specific (i.e. workplace, school, household, leisure-venue) transmissibility parameter that integrates consideration of both the ***amount of time spent in a location*** and ***the inherent "riskiness"*** **of a location** (i.e. how receptive to onwards transmission it is). Currently within the model, each Location Type (i.e. workplace, school, household, leisure-venue) has a specific $\beta$ (i.e. $\beta_{W}$,$\beta_{S}$ , $\beta_{H}$, $\beta_{L}$ respectively) and all individual locations within a Location Type (e.g. all schools) have the same $\beta$ (though this could be changed in future versions).
+where $I_m(t)$ are the number of infectious individuals in location $m$ at time $t$, $N_m$ are the total number of individuals visiting location $m$ at time $t$ and $\beta_m$ is a location specific (i.e. workplace, school, household, leisure-venue) transmissibility parameter that integrates consideration of both the ***amount of time spent in a location*** and ***the inherent "riskiness"*** **of a location** (i.e. how receptive to onwards transmission it is).
+Currently within the model, each setting type has a specific $\beta$ (i.e. $\beta_{W}$,$\beta_{S}$ , $\beta_{H}$, $\beta_{L}$ respectively) and all individual locations within a setting type (e.g. all schools) have the same $\beta$ (though this could be changed in future versions).
 
-The total force of infection $\lambda_T$ for each individual is calculated as a sum of household, workplace, school and leisure force of infections. We add an additional force of infection term $\lambda_C$ to represent types of potential infectious contacts not represented by the locations we consider (e.g. during a commute to/from a workplace, grocery shopping etc). and which represents general mixing among all people. The total Force of Infection experienced by individual $i$ is therefore calculated as:
-
-$$ \lambda_{i, T} = \lambda_{i, H} + \lambda_{i, W} + \lambda_{i, S} + \lambda_{i, L} + \lambda_{i, C} $$
-
-The probability of individual $i$ becoming infected during one time-step $t$ is calculated by summing the Location-specific force of infections they experience and then calculating the following:
-
+The total force of infection $\lambda_T$ for each individual is calculated as a sum of household, workplace, school and leisure force of infections.
+We add an additional force of infection term $\lambda_C$ to represent types of potential infectious contacts not represented by the setting types we consider (e.g. during a commute to/from a workplace, grocery shopping etc.) and which represents general mixing among all people.
+The total force of infection experienced by individual $i$ is therefore calculated as:
 $$
-P(infection) = 1 - \exp(- \lambda_{i,T}t).
+\lambda_{i, T} = \lambda_{i, H} + \lambda_{i, W} + \lambda_{i, S} + \lambda_{i, L} + \lambda_{i, C}
+$$
+The probability of individual $i$ becoming infected during one time-step $t$ is calculated by summing the setting-specific force of infections they experience and then calculating the following:
+$$
+P(\text{infection}) = 1 - \exp(- \lambda_{i,T}t).
 $$
 
-Exposed individuals become infectious after some delay (the *incubation period*). Infectious individuals recover after some delay (the *duration of infectiousness*). After recovering, individuals can then return to being susceptible (reflecting the loss of acquired immunity to infection), again after some delay. By altering the duration of acquired immunity to infection, the framework has the capacity to simulate both epidemic (those producing a single "epidemic wave" before dying out) and endemic (those which are constantly present in the population) pathogens (Figure \@ref(fig:epidemic-endemic)).
+Exposed individuals become infectious after some delay (the *incubation period*).
+Infectious individuals recover after some delay (the *duration of infectiousness*).
+After recovering, individuals can then return to being susceptible (reflecting the loss of acquired immunity to infection), again after some delay.
+By altering the duration of acquired immunity to infection, the framework has the capacity to simulate both epidemic (those producing a single "epidemic wave" before dying out) and endemic (those which are constantly present in the population) pathogens (Figure \@ref(fig:epidemic-endemic)).
 
 (ref:epidemic-endemic) Illustration of simulated epidemic and endemic pathogens.
 
@@ -201,7 +235,7 @@ epidemic_plot <- exemplar_data |>
   scale_color_discrete(type = blueprint_colours) +
   theme(strip.background = element_blank(),
         strip.text = element_text(colour = "#03113E", size = 12),
-        panel.border=element_blank(),
+        panel.border = element_blank(),
         plot.title = element_text(size = 10),
         legend.title = element_blank(),
         legend.position = "right",
@@ -224,7 +258,7 @@ endemic_plot <- exemplar_data |>
   theme(strip.background = element_blank(),
         strip.text = element_text(colour = "#03113E", size = 12),
         plot.title = element_text(size = 10),
-        panel.border=element_blank(),
+        panel.border = element_blank(),
         legend.title = element_blank(),
         legend.position = "right",
         legend.background = element_blank(),
@@ -234,28 +268,27 @@ plot_legend <- cowplot::get_legend(endemic_plot)
 cowplot::plot_grid(epidemic_plot + theme(legend.position = "none"), 
                    endemic_plot + theme(legend.position = "none"),
                    plot_legend, nrow = 1, rel_widths = c(1, 1, 0.4))
-
 ```
 
 ## Modelling Far UVC
 
-Far UVC interventions can be installed in each of the four location types, in any combination (i.e. in either one, two, three, or all four location types). We model the efficacy of far UVC as the reduction in the force of infection an individual experiences in a location where it is installed. Specifically, the force of infection experienced by individual $i$ in Location $m$ at time $t$ where far UVC is installed is calculated as follows:
-
+Far UVC interventions can be installed in each of the four setting types, in any combination (i.e. in either one, two, three, or all four setting types).
+We model the efficacy of far UVC as the reduction in the force of infection an individual experiences in a location where it is installed. Specifically, the force of infection experienced by individual $i$ in location $m$ at time $t$ where far UVC is installed is calculated as follows:
 $$
-\lambda_{i,m}(t) = (1 - E_{UVC})\frac{\beta_{m} I_m(t)}{N_m}
+\lambda_{i,m}(t) = (1 - E_{\text{UVC}})\frac{\beta_{m} I_m(t)}{N_m}
 $$
+where $E_{\text{UVC}}$ is the efficacy of far UVC.
+For example, an efficacy of 50% results in a reduction of the force of infection an individual experiences in that particular location by a half. The efficacy of far UVC within each particular setting type can be set individually (i.e. to produce a setting type specific efficacy.)
 
-where $E_{UVC}$ is the efficacy of far UVC. For example, an efficacy of 50% results in a reduction of the force of infection an individual experiences in that particular location by a half. The efficacy of far UVC within each particular Location Type (i.e. schools, workplaces, leisure venues) can be set individually (i.e. to produce a Location-Type specific efficacy.)
+Within each setting type, the proportion of locations covered by the installation can also be specified.
+Given a certain level of coverage (e.g. 20%), the settings with far UVC installed can be set according to one of two **coverage strategies**:
 
-Within each Location Type, the proportion of locations covered by the installation can also be specified. Given a certain level of coverage (e.g. 20%), the settings with far UVC installed can be set according to one of two **coverage strategies**:
+- **Random:** Locations for far UVC to be installed are sampled at random, with a random 20% of locations of that type selected.
+- **Targeted:** Locations for far UVC to be installed are chosen in order of size, with the largest 20% of locations selected to receive far UVC.
 
--   **Random:** Locations for far UVC to be installed are sampled at random, with a random 20% of locations of that type selected.
+Figure \@ref(fig:uvc) provides an example illustrating the difference between these two strategies as applied to the schools setting type.
 
--   **Targeted:** Locations for far UVC to be installed are chosen in order of size, with the largest 20% of locations selected to receive far UVC.
-
-Figure \@ref(fig:uvc) provides an example illustrating the difference between these two strategies as applied to the schools Location Type.
-
-(ref:uvc) Illustration of the targeted and random strategies for the workplace Location Type.
+(ref:uvc) Illustration of the targeted and random strategies for the workplace setting type.
 
 ```{r uvc, fig.cap="(ref:uvc)"}
 data.frame(workplace_sizes) |>
@@ -289,27 +322,34 @@ data.frame(workplace_sizes) |>
 
 # Illustrative Simulations of Far UVC
 
-What follows is a demonstration of the types of model outputs that `helios` can generate, and how these outputs can be presented graphically. To do this, we have carried out two sets of analyses using the modelling framework to investigate the following:
+What follows is a demonstration of the types of model outputs that `helios` can generate, and how these outputs can be presented graphically.
+To do this, we have carried out two sets of analyses using the modelling framework to investigate the following:
 
-1.  Comparison of random and targeted far UVC deployment under different epidemic pathogen outbreak scenarios
-2.  The impact of far UVC efficacy, coverage and deployment strategy on epidemic final size (i.e. total number of individuals infected) during epidemic pathogen outbreak scenarios
+1. Comparison of random and targeted far UVC deployment under different epidemic pathogen outbreak scenarios.
+2. The impact of far UVC efficacy, coverage and deployment strategy on epidemic final size (i.e. total number of individuals infected) during epidemic pathogen outbreak scenarios.
 
-**The results presented in these figures are illustrative and primarily meant to demonstrate the types of result that the framework can currently produce. They should not be over-interpreted at this early stage, and we note that they will be subject to substantial change following your input, and throughout the model development phase.**
+**The results presented in these figures are illustrative and primarily meant to demonstrate the types of result that the framework can currently produce.**
+**They should not be over-interpreted at this early stage, and we note that they will be subject to substantial change following your input, and throughout the model development phase.**
 
 ## Exploring the impact of far UVC deployment strategies on disease dynamics with `helios`
 
-To assess the potential of far UVC deployment to mitigate transmission, we carried out a number of simulations for a pathogen with characteristics approximately similar to SARS-CoV-2 (R0 of 2), and explored the impact of far UVC on transmission dynamics. Specifically, we compared the transmission dynamics under a no-intervention baseline, random far UVC deployment, and far UVC deployment targeted at the most populous 50% of places within each setting type.
+To assess the potential of far UVC deployment to mitigate transmission, we carried out a number of simulations for a pathogen with characteristics approximately similar to SARS-CoV-2 ($R_0$ of 2), and explored the impact of far UVC on transmission dynamics.
+Specifically, we compared the transmission dynamics under a no-intervention baseline, random far UVC deployment, and far UVC deployment targeted at the most populous 50% of places within each setting type.
 
-These comparisons were performed for both epidemic and endemic pathogens. For epidemic pathogens, we assume that infection by the pathogen confers full and lasting immunity. For endemic pathogens, we assume that immunity following infection with the pathogen is short lived, and wanes. We assumed far UVC efficacy was sufficient to reduce transmission intensity by 75%, and that coverage of far UVC (i.e. the proportion of locations with far UVC installed) was 50%. Further, we assume a 30%\|30%\|30%\|10% split in where transmission takes place (households, workplace/school, leisure venue and in the community, respectively).
+These comparisons were performed for both epidemic and endemic pathogens. For epidemic pathogens, we assume that infection by the pathogen confers full and lasting immunity. For endemic pathogens, we assume that immunity following infection with the pathogen is short lived, and wanes.
+We assumed far UVC efficacy was sufficient to reduce transmission intensity by 75%, and that coverage of far UVC (i.e. the proportion of locations with far UVC installed) was 50%.
+Further, we assume a 30%\|30%\|30%\|10% split in where transmission takes place (households, workplace/school, leisure venue and in the community, respectively).
 
 ### Epidemic Pathogen Simulation
 
-Figure \@ref(fig:exemplar-epidemic) shows the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of an epidemic pathogen. Random indicates that far UVC was assigned to a random 50% of school, workplace and leisure locations. Targeted indicates that far UVC was assigned to the largest 50% of school, workplace and leisure locations.
+Figure \@ref(fig:exemplar-epidemic) shows the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of an epidemic pathogen.
+Random indicates that far UVC was assigned to a random 50% of school, workplace and leisure locations.
+Targeted indicates that far UVC was assigned to the largest 50% of school, workplace and leisure locations.
 
-In the epidemic scenario, having pre-installed far UVC devices in the workplace, school, and leisure settings reduced the number of people who become infected by the pathogen and, when targeted specifically to the most largest settings within a setting type (the "Targeted" strategy), slowed the rate of pathogen spread in the population. Targeted far UVC provided an even greater reduction in the total number of people infected relative to the random deployment than random far UVC deployment provided relative to the no-intervention baseline.
+In the epidemic scenario, having pre-installed far UVC devices in the workplace, school, and leisure settings reduced the number of people who become infected by the pathogen and, when targeted specifically to the most largest settings within a setting type (the "Targeted" strategy), slowed the rate of pathogen spread in the population.
+Targeted far UVC provided an even greater reduction in the total number of people infected relative to the random deployment than random far UVC deployment provided relative to the no-intervention baseline.
 
 ```{r exemplar-epidemic, fig.cap="(ref:exemplar-epidemic)"}
-
 # Plot the epidemic exemplar simulations:
 exemplar_data |>
   filter(Setting == "Epidemic") |>
@@ -330,20 +370,21 @@ exemplar_data |>
         legend.position = c(0.93, 0.85),
         legend.background = element_blank(),
         axis.line = element_line()) 
-
 ```
 
 (ref:exemplar-epidemic) Illustration of the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of a theoretical pathogen when full and lasting immunity to infection is acquired by infected individuals (i.e. the pathogen induces a single epidemic).
 
 ### Endemic Pathogen Simulation
 
-Figure \@ref(fig:exemplar-endemic) shows the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of a theoretical pathogen, when the immunity acquired during infection wanes over time. Random indicates that far UVC was assigned to a random 50% of school, workplace and leisure locations. Targeted indicates that far UVC was assigned to the largest 50% of school, workplace and leisure locations.
+Figure \@ref(fig:exemplar-endemic) shows the effect of random and targeted far UVC deployment, relative to an interventionless baseline, on the disease state dynamics of a theoretical pathogen, when the immunity acquired during infection wanes over time.
+Random indicates that far UVC was assigned to a random 50% of school, workplace and leisure locations.
+Targeted indicates that far UVC was assigned to the largest 50% of school, workplace and leisure locations.
 
-In the endemic scenario, where a pathogen is already established in the human population, introducing far UVC decreased the proportion of individuals in the population with infections relative to the no-intervention baseline scenario (Figure \@ref(fig:exemplar-endemic)). Again, targeting far UVC deployment provided additional benefits to pathogen suppression.
+In the endemic scenario, where a pathogen is already established in the human population, introducing far UVC decreased the proportion of individuals in the population with infections relative to the no-intervention baseline scenario (Figure \@ref(fig:exemplar-endemic)).
+Again, targeting far UVC deployment provided additional benefits to pathogen suppression.
 
 ```{r exemplar-endemic, fig.cap="(ref:exemplar-endemic)"}
-
-# Plot the epidemic exemplar simulations:
+# Plot the endemic exemplar simulations:
 exemplar_data |>
   filter(Setting == "Endemic") |>
   filter(timestep %in% c(400:1000)) |>
@@ -358,7 +399,7 @@ exemplar_data |>
   facet_grid(~Intervention) +
   theme(strip.background = element_blank(),
         strip.text = element_text(colour = "#03113E", size = 12),
-        panel.border=element_blank(),
+        panel.border = element_blank(),
         legend.title = element_blank(),
         legend.position = c(0.93, 0.5),
         legend.background = element_blank(),
@@ -370,136 +411,89 @@ exemplar_data |>
 
 ## Assessing how various far UVC parameters shape epidemic final size
 
-In addition to the outputs presented above (which show the results of a single simulation with a single parameter set), we can also use `helios` framework to explore how key outputs (the total number of individuals infected) varies with changes to input parameters. This is known as a "sensitivity analysis" and we present illustrative results from an example sensitivity analysis below.
+In addition to the outputs presented above (which show the results of a single simulation with a single parameter set), we can also use `helios` framework to explore how key outputs (the total number of individuals infected) varies with changes to input parameters.
+This is known as a "sensitivity analysis" and we present illustrative results from an example sensitivity analysis below.
 
-We simulated an epidemic (infection with the pathogen confers full and lasting immunity) with varying levels of transmission intensity (R0) and assessed the sensitivity of final epidemic size (defined as the total proportion of the population that gets infected during the course of an epidemic) to variation in far UVC coverage, far UVC efficacy, and deployment strategy (Targeted or Random).
+We simulated an epidemic (infection with the pathogen confers full and lasting immunity) with varying levels of transmission intensity ($R_0$) and assessed the sensitivity of final epidemic size (defined as the total proportion of the population that gets infected during the course of an epidemic) to variation in far UVC coverage, far UVC efficacy, and deployment strategy (Targeted or Random).
 
-Figures \@ref(fig:sweep-R0-coverage) and \@ref(fig:sweep-R0-efficacy) illustrate how `helios` model outputs can be graphed, depicting how the final epidemic size changes with R0, far UVC coverage, far UVC efficacy, and far UVC deployment strategy. In general, for a given transmission intensity (R0), increasing the coverage (Figure \@ref(fig:sweep-R0-coverage)) or efficacy (Figures \@ref(fig:sweep-R0-efficacy)) of far UVC reduced the final size of the epidemic.
+Figures \@ref(fig:sweep-R0-coverage) and \@ref(fig:sweep-R0-efficacy) illustrate how `helios` model outputs can be graphed, depicting how the final epidemic size changes with $R_0$, far UVC coverage, far UVC efficacy, and far UVC deployment strategy. In general, for a given transmission intensity ($R_0$), increasing the coverage (Figure \@ref(fig:sweep-R0-coverage)) or efficacy (Figures \@ref(fig:sweep-R0-efficacy)) of far UVC reduced the final size of the epidemic.
 
-For low transmission intensities (R0 $\leq$ 1.5), very high levels of far UVC coverage and/or prevented the epidemic from occurring (final epidemic size \~0%). Across the majority of combinations of R0, far UVC coverage, and far UVC efficacy, targeting the deployment of far UVC to the most populous settings achieved a greater reduction in final epidemic size.
+For low transmission intensities ($R_0 \leq 1.5$), very high levels of far UVC coverage and/or prevented the epidemic from occurring (final epidemic size \~0%). Across the majority of combinations of $R_0$, far UVC coverage, and far UVC efficacy, targeting the deployment of far UVC to the most populous settings achieved a greater reduction in final epidemic size.
 
-### Sensitivity Analysis of R0 & far UVC Coverage
+### Sensitivity Analysis of $R_0$ and far UVC Coverage
 
 ```{r sweep-R0-coverage, fig.cap="(ref:sweep-R0-coverage)"}
+coverage_over_time <- parameter_sweep_data |>
+  filter(efficacy == 0.8, coverage <= 1) |>
+  ggplot(aes(x = 100 * coverage, y = 100 * final_size, col = factor(R0))) +
+  geom_line() +
+  facet_grid(. ~ Coverage_Strategy) +
+  theme_bw() +
+  theme(strip.background = element_rect(fill = "white", colour = "black")) +
+  labs(x = "Coverage %", y = "Epidemic Final Size", colour = "R0")
 
-# Plot the epidemic exemplar simulations:
-a <- cowplot::plot_grid(
-  
-  # Plot the coverage through time:
-  parameter_sweep_data |>
-    filter(efficacy == 0.8, coverage <= 1) |>
-    ggplot(aes(x = 100 * coverage, y = 100 * final_size, col = factor(R0))) +
-    geom_line() +
-    facet_grid(.~Coverage_Strategy) +
-    theme_bw() +
-    theme(strip.background = element_rect(fill="white", colour = "black")) +
-    labs(x = "Coverage %", y = "Epidemic Final Size", colour = "R0"), 
-  
-  # Plot the heatmap of R0 against coverage for proportion contained:
-  parameter_sweep_data |>
-    filter(efficacy == 0.8, coverage <= 1) |>
-    ggplot(aes(y = factor(R0), x = 100 * coverage, fill = 100 * final_size)) +
-    geom_tile(colour = "black") +
-    scale_fill_viridis_c(option = "rocket",
-                         limits = c(0, 100),
-                         begin = 0,
-                         end = 1,
-                         name = "Proportion\nContained",
-                         direction = -1) +
+heatmap_contained <- parameter_sweep_data |>
+  filter(efficacy == 0.8, coverage <= 1) |>
+  ggplot(aes(y = factor(R0), x = 100 * coverage, fill = 100 * final_size)) +
+  geom_tile(colour = "black") +
+  scale_fill_viridis_c(option = "rocket", limits = c(0, 100), begin = 0,
+                       end = 1, name = "Proportion\nContained", direction = -1) +
     scale_x_continuous(breaks = c(0, 20, 40, 60, 80, 100),
                        labels = c(0, 20, 40, 60, 80, 100)) +
-    facet_grid(.~Coverage_Strategy) +
-    labs(y = "R0",
-         x = "farUVC Coverage (%)") +
+    facet_grid(. ~ Coverage_Strategy) +
+    labs(y = "R0", x = "farUVC Coverage (%)") +
     theme(axis.text = element_text(angle = 0),
           plot.title = element_text(hjust = 0.5, size = 20, face = "bold"),
           legend.title = element_text(size = 12),
           legend.text = element_text(size = 12),
           legend.position = "right",
-          strip.background = element_rect(fill="white", colour = "black"),
+          strip.background = element_rect(fill = "white", colour = "black"),
           panel.border = element_rect(linetype = "solid", fill = NA, linewidth = 0.5)) +
-    coord_cartesian(expand = FALSE),
-  
-  # Split the two figures across separate rows:
-  nrow = 2,
-  
-  # Align the figures horizontally 
-  align = "hv", 
-  
-  # Not sure
-  axis = "lr",
-  
-  # Specify the relative heights of the two figures:
-  rel_heights = c(1, 2)
-  
-)
+    coord_cartesian(expand = FALSE)
 
-# cowplot::plot_grid(a, b, nrow = 2, labels = c("A", "B"))
-a
-
+# Align the figures in both directions
+cowplot::plot_grid(coverage_over_time, heatmap_contained, nrow = 2,
+                   align = "hv", axis = "lr", rel_heights = c(1, 2))
 ```
 
-(ref:sweep-R0-coverage) The effect of R0 and far UVC efficacy, under random and targeted far UVC deployment, on the proportion of the population that a pathogen infects assuming a far UVC efficacy of 80%.
+(ref:sweep-R0-coverage) The effect of $R_0$ and far UVC efficacy, under random and targeted far UVC deployment, on the proportion of the population that a pathogen infects assuming a far UVC efficacy of 80%.
 
-### Sensitivity Analysis of R0 & far UVC Efficacy
+### Sensitivity Analysis of $R_0$ and far UVC Efficacy
 
 ```{r sweep-R0-efficacy, fig.cap="(ref:sweep-R0-efficacy)"}
+coverage_over_time <- parameter_sweep_data |>
+  filter(coverage > 0.7 & coverage < 1) |>
+  ggplot(aes(x = 100 * efficacy, y = 100 * final_size, col = factor(R0))) +
+  geom_line() +
+  facet_grid(. ~ Coverage_Strategy) +
+  theme_bw() +
+  theme(strip.background = element_rect(fill="white", colour = "black")) +
+  labs(x = "Efficacy %", y = "Epidemic Final Size", colour = "R0")
 
-b <- cowplot::plot_grid(
-  
-  # Plot the coverage through time:
-  parameter_sweep_data |>
-    filter(coverage > 0.7 & coverage < 1) |>
-    ggplot(aes(x = 100 * efficacy, y = 100 * final_size, col = factor(R0))) +
-    geom_line() +
-    facet_grid(.~Coverage_Strategy) +
-    theme_bw() +
-    theme(strip.background = element_rect(fill="white", colour = "black")) +
-    labs(x = "Efficacy %", y = "Epidemic Final Size", colour = "R0"), 
-  
-  # Plot the heatmap of R0 against efficacy for proportion contained:
-  parameter_sweep_data |>
-    filter(coverage > 0.7 & coverage < 1) |>
-    ggplot(aes(y = factor(R0), x = 100 * efficacy, fill = 100 * final_size)) +
-    geom_tile(colour = "black") +
-    scale_fill_viridis_c(option = "mako", 
-                         limits = c(0, 100),
-                         begin = 0, 
-                         end = 1, 
-                         name = "Proportion\nContained",
-                         direction = -1) +
+heatmap_contained <- parameter_sweep_data |>
+  filter(coverage > 0.7 & coverage < 1) |>
+  ggplot(aes(y = factor(R0), x = 100 * efficacy, fill = 100 * final_size)) +
+  geom_tile(colour = "black") +
+  scale_fill_viridis_c(option = "mako", limits = c(0, 100),begin = 0, end = 1,
+                       name = "Proportion\nContained", direction = -1) +
     scale_x_continuous(breaks = c(0, 20, 40, 60, 80, 100),
                        labels = c(0, 20, 40, 60, 80, 100)) +
-    facet_grid(.~Coverage_Strategy) +
-    labs(y = "R0",
-         x = "farUVC Efficacy (%)") +
+    facet_grid(. ~ Coverage_Strategy) +
+    labs(y = "R0", x = "farUVC Efficacy (%)") +
     theme(axis.text = element_text(angle = 0),
           plot.title = element_text(hjust = 0.5, size = 20, face = "bold"),
           legend.title = element_text(size = 12),
           legend.text = element_text(size = 12),
           legend.position = "right",
-          strip.background = element_rect(fill="white", colour = "black"),
+          strip.background = element_rect(fill = "white", colour = "black"),
           panel.border = element_rect(linetype = "solid", fill = NA, linewidth = 0.5)) +
-    coord_cartesian(expand = FALSE),
-  
-  # Split the two figures across separate rows:
-  nrow = 2,
-  
-  # Align the figures horizontally 
-  align = "hv", 
-  
-  # Not sure
-  axis = "lr",
-  
-  # Specify the relative heights of the two figures:
-  rel_heights = c(1, 2)
-  
-)
+    coord_cartesian(expand = FALSE)
 
-b
-
+# Align the figures in both directions
+cowplot::plot_grid(coverage_over_time, heatmap_contained, nrow = 2,
+                   align = "hv", axis = "lr", rel_heights = c(1, 2))
 ```
 
-(ref:sweep-R0-efficacy) The effect of R0 and far UVC efficacy, under random and targeted far UVC deployment, on the proportion of the population that a pathogen infects assuming a far UVC coverage of 80% is achieved.
+(ref:sweep-R0-efficacy) The effect of $R_0$ and far UVC efficacy, under random and targeted far UVC deployment, on the proportion of the population that a pathogen infects assuming a far UVC coverage of 80% is achieved.
 
 # Bibliography {.unnumbered}


### PR DESCRIPTION
In starting to work on the July report for Blueprint I made some edits to the old report:

* Put each new sentence on a new line
 * Replace instances of "location type" (or "Location Type") with setting type
  * Use \text{} in some maths formulas
  * Replace "R0" in text by "$R_0$"
  * Replace "&" in text by "and"
  * Sentence-case titles
  * Use `scales::percent` in figures

As we are not going to edit the old report now, I'm moving these changes to this PR, which can be reviewed / merged at leisure (it's not time sensitive).

Some of these are more like "my opinion" and some I think are more clear improvements (e.g. using `scales::percent`).

I think a broader question here is whether we can essentially write the paper from this report by making improvements to it (obviously more important ones than these cosmetics).